### PR TITLE
adding null check for this.outputPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ class S3Downloader {
   }
 
   removeOldApp() {
+    if (!this.outputPath) {
+      return Promise.resolve();
+    }
+    
     this.ui.writeLine('removing ' + this.outputPath);
     return fsp.remove(this.outputPath);
   }


### PR DESCRIPTION
fix for error below happening on removeOldApp() when path is null or empty

[2016-12-31T10:37:19.170Z][m75199] downloading app
[2016-12-31T10:37:19.170Z][m75199] fetching current app version from fastboot-test/fastboot-deploy-info.json
[2016-12-31T10:37:19.429Z][m75199] got config { bucket: 'fastboot-test', key: 'dist.zip' }
[2016-12-31T10:37:19.431Z][m75199] removing
[2016-12-31T10:37:19.432Z][m75199] Error downloading app
[2016-12-31T10:37:19.433Z][m75199] AssertionError: rimraf: missing path