### PR TITLE
Use signature version 4 for authorization

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const fsp  = require('fs-promise');
 const exec = require('child_process').exec;
 
 const s3 = new AWS.S3({
-  apiVersion: '2006-03-01'
+  apiVersion: '2006-03-01',
+  signatureVersion: 'v4'
 });
 
 function AppNotFoundError(message) {


### PR DESCRIPTION
To allow S3 access to buckets in all regions, see http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html.

Especially relevant after the recent us-east-1 outage! ;)

@tomdale mentioning you because it seems (again ;)) you are not watching this repo, don't know if you get notifications otherwise. Also the case for several other fastboot repos...