### PR TITLE
Add support for custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ let downloader = new S3Downloader({
   key: S3_KEY,
   accessKeyId: AWS_KEY, // optional
   secretAccessKey: AWS_SECRET, // optional
-  region: AWS_REGION // optional
+  region: AWS_REGION, // optional
+  endpoint: AWS_ENDPOINT_URL // optional
 });
 
 let server = new FastBootAppServer({

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ class S3Downloader {
       signatureVersion: 'v4',
       accessKeyId: options.accessKeyId,
       secretAccessKey: options.secretAccessKey,
-      region: options.region
+      region: options.region,
+      endpoint: options.endpoint
     });
   }
 


### PR DESCRIPTION
Specifying a custom endpoint allows you to use an AWS S3 compatible API like [Minio](https://minio.io) or Digital Ocean's new [Spaces](https://www.digitalocean.com/products/object-storage/) product.