### PR TITLE
Remove app zip file when it is no longer needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class S3Downloader {
       .then(() => this.downloadAppZip())
       .then(() => this.unzipApp())
       .then(() => this.installNPMDependencies())
+      .then(() => this.removeAppZip())
       .then(() => this.outputPath);
   }
 
@@ -105,6 +106,13 @@ class S3Downloader {
       .then(() => {
         this.ui.writeLine("unzipped " + zipPath);
       });
+  }
+
+  removeAppZip() {
+    let zipPath = this.zipPath;
+
+    this.ui.writeLine('removing ' + this.zipPath);
+    return fsp.remove(this.zipPath);
   }
 
   installNPMDependencies() {


### PR DESCRIPTION
I noticed our deployment servers were collecting more and more `dist-XXX.zip` files with each deploy. This small change has `fastboot-s3-downloader` cleanup after itself by removing the zip file once it is no longer needed.