### PR TITLE
Update link to fastboot-s3-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ all of your app servers when you deploy a new version. Instead, they can
 just grab a fixed file to determine the current version.
 
 If you like this, you may also be interested in the companion
-[fastboot-s3-notifier](https://github.com/tomdale/fastboot-s3-notifier).
+[fastboot-s3-notifier](https://github.com/ember-fastboot/fastboot-s3-notifier).


### PR DESCRIPTION
Now that `fastboot-s3-notifier` (and downloader) have been moved to the `ember-fastboot` organization, its `README` link needs to be updated. 🎈 